### PR TITLE
fix: prevent crash when calling .some() on undefined

### DIFF
--- a/src/models/GroupEvent.ts
+++ b/src/models/GroupEvent.ts
@@ -295,7 +295,7 @@ export function initializeGroupEvent(uid: string, data: TGroupEvent, type: Group
             type,
             data: baseData,
             threadId,
-            isSelf: baseData.updateMembers.some((member) => member.id == uid) || baseData.sourceId == uid,
+            isSelf: baseData.updateMembers?.some((member) => member.id == uid) || baseData.sourceId == uid,
         };
     }
 }


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'some')
    at initializeGroupEvent (node_modules/zca-js/dist/models/GroupEvent.js:79:44)