### PR TITLE
fix(cookie): set correct domain to avoid issues (#212)

### DIFF
--- a/src/zalo.ts
+++ b/src/zalo.ts
@@ -50,7 +50,6 @@ export class Zalo {
         const jar = new toughCookie.CookieJar();
         for (const each of cookieArr) {
             try {
-                // hotfix: set cookie with correct domain to avoid issues
                 const cookieObj = toughCookie.Cookie.fromJSON({
                     ...each,
                     key: (each as toughCookie.SerializedCookie).key || each.name,


### PR DESCRIPTION
What does this PR do?
Fixes cookie domain mismatch by dynamically setting the URL based on the cookie's domain instead of using a hardcoded host.

Reason for this PR
Fixes error: Error: Cookie not in this host's domain introduced in v2.0.0-beta.26 when cookies from id.zalo.me were set to chat.zalo.me.

How did you verify your code works?
[x] All related features have been fully tested

[x] Code changes verified

Related Issue (if any)
Fixes #212

Testing Instructions
Run login() with stored cookies and verify no domain errors appear in the console.