### PR TITLE
Correct profile object structure in FetchAccountInfoResponse type

### DIFF
--- a/src/apis/fetchAccountInfo.ts
+++ b/src/apis/fetchAccountInfo.ts
@@ -2,7 +2,7 @@ import { apiFactory } from "../utils.js";
 
 import type { User } from "../models/index.js";
 
-export type FetchAccountInfoResponse = User;
+export type FetchAccountInfoResponse = { profile: User };
 
 export const fetchAccountInfoFactory = apiFactory<FetchAccountInfoResponse>()((api, _, utils) => {
     const serviceURL = utils.makeURL(`${api.zpwServiceMap.profile[0]}/api/social/profile/me-v2`);


### PR DESCRIPTION
## What does this PR do?
Correct the `profile` object type definition in `FetchAccountInfoResponse` to match the actual structure returned by the API.

## Reason for this PR
The `profile` object in `FetchAccountInfoResponse` was incorrectly typed, causing a mismatch between the declared type and the actual API response. This led to incorrect type hints and potential runtime issues when accessing profile fields.

## How did you verify your code works?
- [x] All related features have been fully tested
- [x] Unit tests have been updated/created if needed
- [x] No lint/format errors
- [ ] Documentation has been updated if needed
- [x] Code changes

## Related Issue (if any)
<!-- Attach a link to the related issue or ticket -->
N/A

## Testing Instructions
1. Call `fetchAccountInfo()` and inspect the response
2. Confirm TypeScript no longer shows type errors on `response.profile`
3. Verify all fields inside the `profile` object match the actual API response
