### PR TITLE
fix: use getSetCookie() to properly parse set-cookie headers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -298,8 +298,17 @@ export async function request(ctx: ContextBase, url: string, options?: RequestIn
     const response = await ctx.options.polyfill(url, _options);
     const setCookieRaw = response.headers.get("set-cookie");
     if (setCookieRaw && !raw) {
-        const splitCookies = setCookieRaw.split(", ");
-        for (const cookie of splitCookies) {
+        // Use getSetCookie() (Node.js 18+) to properly parse multi-cookie headers.
+        // The split(", ") method breaks cookies containing Expires dates with commas
+        // (e.g., "Expires=Wed, 18 Mar 2026..."), causing critical cookies like
+        // zpsid and zpw_sek to be lost during QR login flow.
+        let cookieStrings: string[];
+        if (typeof response.headers.getSetCookie === "function") {
+            cookieStrings = response.headers.getSetCookie();
+        } else {
+            cookieStrings = setCookieRaw.split(", ");
+        }
+        for (const cookie of cookieStrings) {
             const parsed = toughCookie.Cookie.parse(cookie);
             try {
                 if (parsed) await ctx.cookie.setCookie(parsed, parsed.domain != "zalo.me" ? `https://${parsed.domain}` : origin);
@@ -310,6 +319,7 @@ export async function request(ctx: ContextBase, url: string, options?: RequestIn
     }
 
     const redirectURL = response.headers.get("location");
+
     if (redirectURL) {
         const redirectOptions = { ...options };
         redirectOptions.method = "GET";


### PR DESCRIPTION
## What does this PR do?
Replace setCookieRaw.split(", ") with response.headers.getSetCookie() (Node.js 18+) in the request() function in src/utils.ts for properly parsing multi-value Set-Cookie headers.

## Reason for this PR
The current split(", ") method corrupts cookies that contain Expires dates with commas. For example:

```
Set-Cookie: zpsid=xxx; Expires=Wed, 18 Mar 2026 04:07:37 GMT; Path=/; Domain=.zalo.me
```

When split by ", ", this becomes:
- zpsid=xxx; Expires=Wed — broken
- 18 Mar 2026 04:07:37 GMT; Path=/; Domain=.zalo.me — garbage

This causes critical authentication cookies (zpsid, zpw_sek) to be lost during the checkSession redirect chain in QR login, resulting in getUserInfo returning { logged: false, require_confirm_pwd: true } even after successful QR scan and confirmation.

response.headers.getSetCookie() is a standard Web API available since Node.js 18 (which is already the minimum required version in package.json). It returns each Set-Cookie header as a separate array element, completely avoiding comma-based splitting issues. A fallback to the old split(", ") is kept for environments where getSetCookie() is unavailable.

## How did you verify your code works?
- [x] All related features have been fully tested
- [x] No lint/format errors
- [x] Code changes

**Before fix:**
```
userInfo { error_message: 'Thanh cong', data: { logged: false, require_confirm_pwd: true }, error_code: 0 }
-> ZaloApiError: Can't login
```

**After fix:**
```
userInfo { error_message: 'Ban da dang nhap truoc day', data: { logged: true, session_chat_valid: true, info: { name: 'XXXX', ... } }, error_code: 0 }
-> Login successful
```

Debug confirmed that after the fix, zpsid and zpw_sek cookies are properly stored in the CookieJar and sent to jr.chat.zalo.me during getUserInfo.

## Related Issue (if any)
#296 

## Testing Instructions
1. Call loginQR() to initiate QR login
2. Scan the QR code with Zalo mobile app and confirm
3. Verify that getUserInfo returns { logged: true } instead of { logged: false, require_confirm_pwd: true }
