### PR TITLE
fix(apis): retry listener on abnormal closure (1006)

### DIFF
--- a/src/apis/listen.ts
+++ b/src/apis/listen.ts
@@ -36,6 +36,7 @@ export enum CloseReason {
 interface ListenerEvents {
     connected: [];
     disconnected: [code: CloseReason, reason: string];
+    reconnecting: [code: CloseReason];
     closed: [code: CloseReason, reason: string];
     error: [error: unknown];
     typing: [typing: Typing];
@@ -143,27 +144,46 @@ export class Listener extends EventEmitter<ListenerEvents> {
         this.onMessageCallback = cb;
     }
 
-    private canRetry(code: CloseReason) {
-        if (!this.ctx.settings.features.socket.close_and_retry_codes.includes(code)) return false;
-        if (this.retryCount[code.toString()].count >= this.retryCount[code.toString()].max) return false;
-        this.retryCount[code.toString()].count++;
+    private isRetryable(code: CloseReason) {
+        return (
+            code === CloseReason.AbnormalClosure ||
+            this.ctx.settings.features.socket.close_and_retry_codes.includes(code)
+        );
+    }
 
-        const { count, max, times } = this.retryCount[code.toString()];
+    private canRetry(code: CloseReason) {
+        if (!this.isRetryable(code)) return false;
+
+        const retry = this.retryCount[code.toString()] ?? this.retryCount["internal"];
+        if (!retry || retry.count >= retry.max) return false;
+        retry.count++;
+
+        const { count, max, times } = retry;
         const retryTime = count - 1 < times.length ? times[count - 1] : times[times.length - 1];
         logger(this.ctx).verbose(`Retry for code ${code} in ${retryTime}ms (${count}/${max})`);
 
         return retryTime;
     }
 
+    private resetRetryCount() {
+        for (const retry of Object.values(this.retryCount)) {
+            retry.count = 0;
+        }
+    }
+
     private shouldRotate(code: CloseReason) {
-        if (!this.ctx.settings.features.socket.rotate_error_codes.includes(code)) return false;
-        if (this.rotateCount >= this.urls.length - 1) return false;
+        if (
+            code !== CloseReason.AbnormalClosure &&
+            !this.ctx.settings.features.socket.rotate_error_codes.includes(code)
+        ) {
+            return false;
+        }
 
         return true;
     }
 
     private rotateEndpoint() {
-        this.rotateCount++;
+        this.rotateCount = (this.rotateCount + 1) % this.urls.length;
         this.wsURL = makeURL(this.ctx, this.urls[this.rotateCount], {
             t: Date.now(),
         });
@@ -193,6 +213,7 @@ export class Listener extends EventEmitter<ListenerEvents> {
         this.ws = ws;
 
         ws.onopen = () => {
+            this.resetRetryCount();
             this.onConnectedCallback();
             this.emit("connected");
         };
@@ -200,12 +221,16 @@ export class Listener extends EventEmitter<ListenerEvents> {
         ws.onclose = (event) => {
             this.reset();
             this.emit("disconnected", event.code as CloseReason, event.reason);
-            const retry = retryOnClose && this.canRetry(event.code as CloseReason);
+            const retry =
+                retryOnClose &&
+                this.isRetryable(event.code as CloseReason) &&
+                this.canRetry(event.code as CloseReason);
             if (retry && retryOnClose) {
                 const shouldRotate = this.shouldRotate(event.code as CloseReason);
                 if (shouldRotate) {
                     this.rotateEndpoint();
                 }
+                this.emit("reconnecting", event.code as CloseReason);
                 setTimeout(() => {
                     this.start({ retryOnClose: true });
                 }, retry);


### PR DESCRIPTION
Zalo force-closes the websocket every ~60s with code `1006` (abnormal closure) regardless of heartbeat pings. Since `1006` is not in the server-provided `close_and_retry_codes` list, `
etryOnClose: true` never fired and the listener died permanently - the real-world case where reconnection is needed most.

### Changes
- Treat `CloseReason.AbnormalClosure` (1006) as retryable when `
etryOnClose` is enabled
- Fall back to the `internal` retry schedule when the close code has no entry in the server retries map (previously would throw `Cannot read properties of undefined`)
- Reset retry counts on a successful connection so each connection gets a fresh budget
- Rotate the endpoint on abnormal closure, wrapping around the host list like the official web client
- Emit a new `
econnecting` event before retrying so clients can track state

### Verification (live, real account)
- Connect → server closed WS with code 1006 after ~22s / ~65s → listener re-emitted `connected` ~2s later
- Listener stays alive across repeated abnormal closures

### Tested against

- `main`: `retryOnClose` ignored 1006, listener closed permanently
- This branch: auto-reconnect works